### PR TITLE
Use CMAKE_CXX_STANDARD to set C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,10 @@ set(
     -DF_CPU=${ATMEL_AVR_F_CPU}UL \
     "
 )
+set( CMAKE_CXC_STANDARD 17 )
 set(
     CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} \
-    -std=c++17 \
     -Werror -Wall -Wextra \
     -Wcast-align=strict \
     -Wcast-qual \


### PR DESCRIPTION
Resolves #43.