### PR TITLE
CI workflow license boilerplate lists the wrong project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# cmake-utilities
+# toolchain-avr-gcc
 #
 # Copyright 2020 Andrew Countryman <apcountryman@gmail.com>
 #


### PR DESCRIPTION
Resolves #47.