### PR TITLE
Fix avrdude programming target creation utility usage examples

### DIFF
--- a/avrdude-utilities.cmake
+++ b/avrdude-utilities.cmake
@@ -344,6 +344,7 @@ endfunction( add_avrdude_programming_targets )
 # EXAMPLES
 #     add_avrdude_programming_target(
 #         example
+#         program-flash-eeprom
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE
 #         OPERATIONS flash:w eeprom:w
@@ -351,6 +352,7 @@ endfunction( add_avrdude_programming_targets )
 #     )
 #     add_avrdude_programming_target(
 #         example
+#         program-flash-eeprom
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE
 #         OPERATIONS flash:w eeprom:w
@@ -358,6 +360,7 @@ endfunction( add_avrdude_programming_targets )
 #     )
 #     add_avrdude_programming_target(
 #         example
+#         program-flash-eeprom
 #         RESET
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE


### PR DESCRIPTION
Resolves #110 (Fix avrdude programming target creation utility usage examples).

The usage examples did not include the target_postfix positional argument.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
