### PR TITLE
Remove EEPROM operations from avrdude programming target creation utility examples

### DIFF
--- a/avrdude-utilities.cmake
+++ b/avrdude-utilities.cmake
@@ -347,7 +347,7 @@ endfunction( add_avrdude_programming_targets )
 #         program-flash-eeprom
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE
-#         OPERATIONS flash:w eeprom:w
+#         OPERATIONS flash:w
 #         ARGUMENTS  -p atmega2560 -c wiring -b 115200 -D
 #     )
 #     add_avrdude_programming_target(
@@ -355,7 +355,7 @@ endfunction( add_avrdude_programming_targets )
 #         program-flash-eeprom
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE
-#         OPERATIONS flash:w eeprom:w
+#         OPERATIONS flash:w
 #         ARGUMENTS  -p atmega328p -c arduino -b 115200 -D
 #     )
 #     add_avrdude_programming_target(
@@ -364,7 +364,7 @@ endfunction( add_avrdude_programming_targets )
 #         RESET
 #         PORT       /dev/ttyACM0
 #         VERBOSITY  VERY_VERBOSE
-#         OPERATIONS flash:w eeprom:w
+#         OPERATIONS flash:w
 #         ARGUMENTS  -p atmega4809 -c jtag2updi -b 115200 -e -D
 #     )
 function( add_avrdude_programming_target executable target_postfix )


### PR DESCRIPTION
Resolves #114 (Remove EEPROM operations from avrdude programming target creation utility examples).

The programmers that were used in the examples may not support EEPROM operations.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
