### PR TITLE
Remove extra spaces from avrdude utilities usage examples

### DIFF
--- a/examples/blink/CMakeLists.txt
+++ b/examples/blink/CMakeLists.txt
@@ -52,11 +52,11 @@ if( ${EXAMPLES_BLINK_ENABLED} )
     add_avrdude_programming_targets(
         blink-c
         ${AVRDUDE_RESET}
-        CONFIGURATION_FILE  ${AVRDUDE_CONFIGURATION_FILE}
-        PORT                ${AVRDUDE_PORT}
-        PROGRAM_FLASH       ${AVRDUDE_PROGRAM_FLASH}
-        VERBOSITY           ${AVRDUDE_VERBOSITY}
-        VERIFY_FLASH        ${AVRDUDE_VERIFY_FLASH}
+        CONFIGURATION_FILE ${AVRDUDE_CONFIGURATION_FILE}
+        PORT               ${AVRDUDE_PORT}
+        PROGRAM_FLASH      ${AVRDUDE_PROGRAM_FLASH}
+        VERBOSITY          ${AVRDUDE_VERBOSITY}
+        VERIFY_FLASH       ${AVRDUDE_VERIFY_FLASH}
     )
 
     add_executable(
@@ -72,10 +72,10 @@ if( ${EXAMPLES_BLINK_ENABLED} )
     add_avrdude_programming_targets(
         blink-c++
         ${AVRDUDE_RESET}
-        CONFIGURATION_FILE  ${AVRDUDE_CONFIGURATION_FILE}
-        PORT                ${AVRDUDE_PORT}
-        PROGRAM_FLASH       ${AVRDUDE_PROGRAM_FLASH}
-        VERBOSITY           ${AVRDUDE_VERBOSITY}
-        VERIFY_FLASH        ${AVRDUDE_VERIFY_FLASH}
+        CONFIGURATION_FILE ${AVRDUDE_CONFIGURATION_FILE}
+        PORT               ${AVRDUDE_PORT}
+        PROGRAM_FLASH      ${AVRDUDE_PROGRAM_FLASH}
+        VERBOSITY          ${AVRDUDE_VERBOSITY}
+        VERIFY_FLASH       ${AVRDUDE_VERIFY_FLASH}
     )
 endif( ${EXAMPLES_BLINK_ENABLED} )


### PR DESCRIPTION
Resolves #116 (Remove extra spaces from avrdude utilities usage examples).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
